### PR TITLE
Advance: done with pockfft, 1d, forward for fft, rfft, hfft cases.

### DIFF
--- a/paddle/fluid/framework/data_type.h
+++ b/paddle/fluid/framework/data_type.h
@@ -170,5 +170,20 @@ extern inline proto::VarType::Type ToComplexType(proto::VarType::Type t) {
   }
 }
 
+extern inline proto::VarType::Type ToRealType(proto::VarType::Type t) {
+  switch (t) {
+    case proto::VarType::COMPLEX64:
+      return proto::VarType::FP32;
+    case proto::VarType::COMPLEX128:
+      return proto::VarType::FP64;
+    default:
+      PADDLE_THROW(platform::errors::Unimplemented(
+          "Unknown complex value data type (%s), now only support complex64 "
+          "and "
+          "complex128.",
+          DataTypeToString(t)));
+  }
+}
+
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/operators/concat_op.cc
+++ b/paddle/fluid/operators/concat_op.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/fluid/operators/concat_op.h"
 
+#include <paddle/fluid/platform/complex.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -234,7 +235,11 @@ REGISTER_OP_CPU_KERNEL(
     ops::ConcatKernel<paddle::platform::CPUDeviceContext,
                       paddle::platform::float16>,
     ops::ConcatKernel<paddle::platform::CPUDeviceContext, int>,
-    ops::ConcatKernel<paddle::platform::CPUDeviceContext, uint8_t>);
+    ops::ConcatKernel<paddle::platform::CPUDeviceContext, uint8_t>,
+    ops::ConcatKernel<paddle::platform::CPUDeviceContext,
+                      paddle::platform::complex<float>>,
+    ops::ConcatKernel<paddle::platform::CPUDeviceContext,
+                      paddle::platform::complex<double>>);
 REGISTER_OP_CPU_KERNEL(
     concat_grad,
     ops::ConcatGradKernel<paddle::platform::CPUDeviceContext, double>,
@@ -244,4 +249,8 @@ REGISTER_OP_CPU_KERNEL(
     ops::ConcatGradKernel<paddle::platform::CPUDeviceContext,
                           paddle::platform::float16>,
     ops::ConcatGradKernel<paddle::platform::CPUDeviceContext, int>,
-    ops::ConcatGradKernel<paddle::platform::CPUDeviceContext, uint8_t>);
+    ops::ConcatGradKernel<paddle::platform::CPUDeviceContext, uint8_t>,
+    ops::ConcatGradKernel<paddle::platform::CPUDeviceContext,
+                          paddle::platform::complex<float>>,
+    ops::ConcatGradKernel<paddle::platform::CPUDeviceContext,
+                          paddle::platform::complex<double>>);

--- a/paddle/fluid/operators/concat_op.cu.cc
+++ b/paddle/fluid/operators/concat_op.cu.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/concat_op.h"
+#include "paddle/fluid/platform/complex.h"
 #include "paddle/fluid/platform/float16.h"
 
 namespace ops = paddle::operators;
@@ -24,7 +25,11 @@ REGISTER_OP_CUDA_KERNEL(
     ops::ConcatKernel<paddle::platform::CUDADeviceContext, plat::float16>,
     ops::ConcatKernel<paddle::platform::CUDADeviceContext, int64_t>,
     ops::ConcatKernel<paddle::platform::CUDADeviceContext, int>,
-    ops::ConcatKernel<paddle::platform::CUDADeviceContext, uint8_t>);
+    ops::ConcatKernel<paddle::platform::CUDADeviceContext, uint8_t>,
+    ops::ConcatKernel<paddle::platform::CUDADeviceContext,
+                      plat::complex<float>>,
+    ops::ConcatKernel<paddle::platform::CUDADeviceContext,
+                      plat::complex<double>>);
 REGISTER_OP_CUDA_KERNEL(
     concat_grad,
     ops::ConcatGradKernel<paddle::platform::CUDADeviceContext, double>,
@@ -33,4 +38,8 @@ REGISTER_OP_CUDA_KERNEL(
     ops::ConcatGradKernel<paddle::platform::CUDADeviceContext, plat::float16>,
     ops::ConcatGradKernel<paddle::platform::CUDADeviceContext, int64_t>,
     ops::ConcatGradKernel<paddle::platform::CUDADeviceContext, int>,
-    ops::ConcatGradKernel<paddle::platform::CUDADeviceContext, uint8_t>);
+    ops::ConcatGradKernel<paddle::platform::CUDADeviceContext, uint8_t>,
+    ops::ConcatGradKernel<paddle::platform::CUDADeviceContext,
+                          plat::complex<float>>,
+    ops::ConcatGradKernel<paddle::platform::CUDADeviceContext,
+                          plat::complex<double>>);

--- a/paddle/fluid/operators/flip_op.cc
+++ b/paddle/fluid/operators/flip_op.cc
@@ -17,6 +17,7 @@ limitations under the License. */
 #include <unordered_map>
 #include <vector>
 #include "paddle/fluid/framework/op_version_registry.h"
+#include "paddle/fluid/platform/complex.h"
 
 namespace paddle {
 namespace operators {
@@ -145,6 +146,7 @@ class FlipOpGradMaker : public framework::SingleGradOpMaker<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
+namespace plat = paddle::platform;
 REGISTER_OPERATOR(flip, ops::FlipOp, ops::FlipOpMaker, ops::FlipOpInferVarType,
                   ops::FlipOpGradMaker<paddle::framework::OpDesc>,
                   ops::FlipOpGradMaker<paddle::imperative::OpBase>);
@@ -153,7 +155,9 @@ REGISTER_OP_CPU_KERNEL(
     ops::FlipKernel<paddle::platform::CPUDeviceContext, double>,
     ops::FlipKernel<paddle::platform::CPUDeviceContext, int32_t>,
     ops::FlipKernel<paddle::platform::CPUDeviceContext, int64_t>,
-    ops::FlipKernel<paddle::platform::CPUDeviceContext, bool>);
+    ops::FlipKernel<paddle::platform::CPUDeviceContext, bool>,
+    ops::FlipKernel<paddle::platform::CPUDeviceContext, plat::complex<float>>,
+    ops::FlipKernel<paddle::platform::CPUDeviceContext, plat::complex<double>>);
 
 /* ==========================  register checkpoint ===========================*/
 REGISTER_OP_VERSION(flip)

--- a/paddle/fluid/operators/flip_op.cu
+++ b/paddle/fluid/operators/flip_op.cu
@@ -16,6 +16,7 @@ limitations under the License. */
 
 #include <vector>
 #include "paddle/fluid/memory/malloc.h"
+#include "paddle/fluid/platform/complex.h"
 
 namespace paddle {
 namespace operators {
@@ -163,4 +164,7 @@ REGISTER_OP_CUDA_KERNEL(
     ops::FlipKernel<paddle::platform::CUDADeviceContext, plat::float16>,
     ops::FlipKernel<paddle::platform::CUDADeviceContext, int>,
     ops::FlipKernel<paddle::platform::CUDADeviceContext, int64_t>,
-    ops::FlipKernel<paddle::platform::CUDADeviceContext, bool>);
+    ops::FlipKernel<paddle::platform::CUDADeviceContext, bool>,
+    ops::FlipKernel<paddle::platform::CUDADeviceContext, plat::complex<float>>,
+    ops::FlipKernel<paddle::platform::CUDADeviceContext,
+                    plat::complex<double>>);

--- a/paddle/fluid/operators/spectral_op.cc
+++ b/paddle/fluid/operators/spectral_op.cc
@@ -350,17 +350,18 @@ struct FFTC2CFunctor<platform::CPUDeviceContext, T> {
   void operator()(const platform::CPUDeviceContext& ctx, const Tensor* x,
                   Tensor* out, const std::vector<int64_t>& axes,
                   FFTNormMode normalization, bool forward) {
+    using R = typename T::value_type;
+    using C = std::complex<R>;
+
     const auto& input_dim = x->dims();
     const std::vector<size_t> in_sizes =
         framework::vectorize<size_t>(input_dim);
     std::vector<int64_t> in_strides =
         framework::vectorize<int64_t>(framework::stride(input_dim));
-    const int64_t data_size = sizeof(T);
+    const int64_t data_size = sizeof(C);
     std::transform(in_strides.begin(), in_strides.end(), in_strides.begin(),
                    [](int64_t s) { return s * data_size; });
 
-    using R = typename T::value_type;
-    using C = std::complex<R>;
     const auto* in_data = reinterpret_cast<const C*>(x->data<T>());
     auto* out_data = reinterpret_cast<C*>(out->data<T>());
     // well, we have to use std::vector<size_t> here
@@ -391,7 +392,7 @@ struct FFTR2CFunctor<platform::CPUDeviceContext, T> {
     std::vector<int64_t> in_strides =
         framework::vectorize<int64_t>(framework::stride(input_dim));
     {
-      const int64_t data_size = sizeof(T);
+      const int64_t data_size = sizeof(R);
       std::transform(in_strides.begin(), in_strides.end(), in_strides.begin(),
                      [](int64_t s) { return s * data_size; });
     }
@@ -438,7 +439,7 @@ struct FFTC2RFunctor<platform::CPUDeviceContext, T> {
     std::vector<int64_t> in_strides =
         framework::vectorize<int64_t>(framework::stride(input_dim));
     {
-      const int64_t data_size = sizeof(T);
+      const int64_t data_size = sizeof(C);
       std::transform(in_strides.begin(), in_strides.end(), in_strides.begin(),
                      [](int64_t s) { return s * data_size; });
     }
@@ -449,7 +450,7 @@ struct FFTC2RFunctor<platform::CPUDeviceContext, T> {
     std::vector<int64_t> out_strides =
         framework::vectorize<int64_t>(framework::stride(output_dim));
     {
-      const int64_t data_size = sizeof(C);
+      const int64_t data_size = sizeof(R);
       std::transform(out_strides.begin(), out_strides.end(),
                      out_strides.begin(),
                      [](int64_t s) { return s * data_size; });

--- a/paddle/fluid/operators/spectral_op.cc
+++ b/paddle/fluid/operators/spectral_op.cc
@@ -33,6 +33,23 @@ namespace operators {
 
 using Tensor = framework::Tensor;
 
+//////////////// C2C
+class FFTC2COpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("X", "(Tensor), the input tensor of fft_c2c op.");
+    AddOutput("Out", "(Tensor), the output tensor of fft_c2c op.");
+    AddAttr<std::vector<int64_t>>("axes",
+                                  "std::vector<int64_t>, the fft axes.");
+    AddAttr<std::string>("normalization",
+                         "fft_norm_type, the fft normalization type.");
+    AddAttr<bool>("forward", "bool, the fft direction.");
+    AddComment(R"DOC(
+      // add doc here
+    )DOC");
+  }
+};
+
 class FFTC2COp : public framework::OperatorWithKernel {
  public:
   using framework::OperatorWithKernel::OperatorWithKernel;
@@ -57,39 +74,6 @@ class FFTC2COp : public framework::OperatorWithKernel {
   }
 };
 
-class FFTC2COpMaker : public framework::OpProtoAndCheckerMaker {
- public:
-  void Make() override {
-    AddInput("X", "(Tensor), the input tensor of fft_c2c op.");
-    AddOutput("Out", "(Tensor), the output tensor of fft_c2c op.");
-    AddAttr<std::vector<int64_t>>("axes",
-                                  "std::vector<int64_t>, the fft axes.");
-    AddAttr<std::string>("normalization",
-                         "fft_norm_type, the fft normalization type.");
-    AddAttr<bool>("forward", "bool, the fft direction.");
-    AddComment(R"DOC(
-      // add doc here
-    )DOC");
-  }
-};
-
-class FFTC2CGradOp : public framework::OperatorWithKernel {
- public:
-  using framework::OperatorWithKernel::OperatorWithKernel;
-
-  void InferShape(framework::InferShapeContext* ctx) const override {
-    // TODO(chenfeiyu): check shape and dim here and generate output dim
-  }
-
- protected:
-  framework::OpKernelType GetExpectedKernelType(
-      const framework::ExecutionContext& ctx) const override {
-    const auto in_dtype = OperatorWithKernel::IndicateVarDataType(ctx, "DOut");
-    const auto kernel_dtype = framework::ToRealType(in_dtype);
-    return framework::OpKernelType(kernel_dtype, ctx.GetPlace());
-  }
-};
-
 template <typename T>
 class FFTC2CGradOpMaker : public framework::SingleGradOpMaker<T> {
  public:
@@ -104,6 +88,231 @@ class FFTC2CGradOpMaker : public framework::SingleGradOpMaker<T> {
   }
 };
 
+class FFTC2CGradOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(
+        ctx->HasInput(framework::GradVarName("Out")), true,
+        platform::errors::InvalidArgument(
+            "Input(%s) of FFTC2CGradOp should not be null.", "DOut"));
+    PADDLE_ENFORCE_EQ(
+        ctx->HasOutput(framework::GradVarName("X")), true,
+        platform::errors::InvalidArgument(
+            "Output(%s) of FFTC2CGradOp should not be null.", "DX"));
+    auto x_grad_name = framework::GradVarName("X");
+    ctx->SetOutputDim(x_grad_name, ctx->GetInputDim("X"));
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    const auto in_dtype = OperatorWithKernel::IndicateVarDataType(
+        ctx, framework::GradVarName("Out"));
+    const auto kernel_dtype = framework::ToRealType(in_dtype);
+    return framework::OpKernelType(kernel_dtype, ctx.GetPlace());
+  }
+};
+
+///////////////// R2C
+class FFTR2COpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("X", "(Tensor), the input tensor of fft_r2c op.");
+    AddOutput("Out", "(Tensor), the output tensor of fft_r2c op.");
+    AddAttr<std::vector<int64_t>>("axes",
+                                  "std::vector<int64_t>, the fft axes.");
+    AddAttr<std::string>("normalization",
+                         "fft_norm_type, the fft normalization type.");
+    AddAttr<bool>("forward", "bool, the fft direction.");
+    AddAttr<bool>("onesided", "bool, perform onesided fft.");
+    AddComment(R"DOC(
+      // add doc here
+    )DOC");
+  }
+};
+
+class FFTR2COp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(ctx->HasInput("X"), true,
+                      platform::errors::InvalidArgument(
+                          "Input(%s) of FFTC2ROp should not be null.", "X"));
+    PADDLE_ENFORCE_EQ(ctx->HasOutput("Out"), true,
+                      platform::errors::InvalidArgument(
+                          "Output(%s) of FFTC2ROp should not be null.", "Out"));
+    const auto axes = ctx->Attrs().Get<std::vector<int64_t>>("axes");
+    const bool onesided = ctx->Attrs().Get<bool>("onesided");
+    if (!onesided) {
+      ctx->ShareDim("X", /*->*/ "Out");  //
+    } else {
+      framework::DDim out_dim(ctx->GetInputDim("X"));
+      const int64_t last_fft_axis = axes.back();
+      const int64_t last_fft_dim_size = out_dim.at(last_fft_axis);
+      out_dim.at(last_fft_axis) = last_fft_dim_size / 2 + 1;
+      ctx->SetOutputDim("Out", out_dim);
+    }
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    const auto in_dtype = OperatorWithKernel::IndicateVarDataType(ctx, "X");
+    return framework::OpKernelType(in_dtype, ctx.GetPlace());
+  }
+};
+
+template <typename T>
+class FFTR2CGradOpMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  void Apply(GradOpPtr<T> grad_op) const override {
+    grad_op->SetType("fft_r2c_grad");
+    grad_op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    grad_op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
+    grad_op->SetAttrMap(this->Attrs());
+  }
+};
+
+class FFTR2CGradOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(
+        ctx->HasInput(framework::GradVarName("Out")), true,
+        platform::errors::InvalidArgument(
+            "Input(%s) of FFTR2CGradOp should not be null.", "DOut"));
+    PADDLE_ENFORCE_EQ(
+        ctx->HasOutput(framework::GradVarName("X")), true,
+        platform::errors::InvalidArgument(
+            "Output(%s) of FFTR2CGradOp should not be null.", "DX"));
+    auto x_grad_name = framework::GradVarName("X");
+    auto out_grad_name = framework::GradVarName("Out");
+    const bool onesided = ctx->Attrs().Get<bool>("onesided");
+    const auto axes = ctx->Attrs().Get<std::vector<int64_t>>("axes");
+    if (!onesided) {
+      ctx->ShareDim(out_grad_name, /*->*/ x_grad_name);  //
+    } else {
+      const auto out_grad_dim = ctx->GetInputDim(out_grad_name);
+      framework::DDim x_grad_dim(out_grad_dim);
+      const int64_t last_fft_axis = axes.back();
+      const int64_t last_fft_dim_size = x_grad_dim.at(last_fft_axis);
+      x_grad_dim.at(last_fft_axis) = (last_fft_dim_size - 1) * 2;
+      ctx->SetOutputDim(x_grad_name, x_grad_dim);
+    }
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    const auto in_dtype = OperatorWithKernel::IndicateVarDataType(
+        ctx, framework::GradVarName("Out"));
+    const auto kernel_dtype = framework::ToRealType(in_dtype);
+    return framework::OpKernelType(kernel_dtype, ctx.GetPlace());
+  }
+};
+
+//////////////// C2R
+class FFTC2ROpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("X", "(Tensor), the input tensor of fft_c2r op.");
+    AddOutput("Out", "(Tensor), the output tensor of fft_c2r op.");
+    AddAttr<std::vector<int64_t>>("axes",
+                                  "std::vector<int64_t>, the fft axes.");
+    AddAttr<std::string>("normalization",
+                         "fft_norm_type, the fft normalization type.");
+    AddAttr<bool>("forward", "bool, the fft direction.");
+    AddComment(R"DOC(
+      // add doc here
+    )DOC");
+  }
+};
+
+class FFTC2ROp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(ctx->HasInput("X"), true,
+                      platform::errors::InvalidArgument(
+                          "Input(%s) of FFTC2ROp should not be null.", "X"));
+    PADDLE_ENFORCE_EQ(ctx->HasOutput("Out"), true,
+                      platform::errors::InvalidArgument(
+                          "Output(%s) of FFTC2ROp should not be null.", "Out"));
+    const auto axes = ctx->Attrs().Get<std::vector<int64_t>>("axes");
+
+    framework::DDim out_dim(ctx->GetInputDim("X"));
+    const int64_t last_fft_axis = axes.back();
+    const int64_t last_fft_dim_size = out_dim.at(last_fft_axis);
+    out_dim.at(last_fft_axis) = (last_fft_dim_size - 1) * 2;
+    ctx->SetOutputDim("Out", out_dim);
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    const auto in_dtype = OperatorWithKernel::IndicateVarDataType(ctx, "X");
+    const auto kernel_dtype = framework::ToRealType(in_dtype);
+    return framework::OpKernelType(kernel_dtype, ctx.GetPlace());
+  }
+};
+
+template <typename T>
+class FFTC2RGradOpMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  void Apply(GradOpPtr<T> grad_op) const override {
+    grad_op->SetType("fft_c2r_grad");
+    grad_op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    grad_op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
+    grad_op->SetAttrMap(this->Attrs());
+  }
+};
+
+class FFTC2RGradOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(
+        ctx->HasInput(framework::GradVarName("Out")), true,
+        platform::errors::InvalidArgument(
+            "Input(%s) of FFTC2RGradOp should not be null.", "DOut"));
+    PADDLE_ENFORCE_EQ(
+        ctx->HasOutput(framework::GradVarName("X")), true,
+        platform::errors::InvalidArgument(
+            "Output(%s) of FFTC2RGradOp should not be null.", "DX"));
+    auto x_grad_name = framework::GradVarName("X");
+    auto out_grad_name = framework::GradVarName("Out");
+    const auto axes = ctx->Attrs().Get<std::vector<int64_t>>("axes");
+
+    const auto out_grad_dim = ctx->GetInputDim(out_grad_name);
+    framework::DDim x_grad_dim(out_grad_dim);
+    const int64_t last_fft_axis = axes.back();
+    const int64_t last_fft_dim_size = x_grad_dim.at(last_fft_axis);
+    x_grad_dim.at(last_fft_axis) = last_fft_dim_size / 2 + 1;
+    ctx->SetOutputDim(x_grad_name, x_grad_dim);
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    const auto in_dtype = OperatorWithKernel::IndicateVarDataType(
+        ctx, framework::GradVarName("Out"));
+    return framework::OpKernelType(in_dtype, ctx.GetPlace());
+  }
+};
+
+//////////////// common
 FFTNormMode get_norm_from_string(const std::string& norm, bool forward) {
   if (norm.empty() || norm == "backward") {
     return forward ? FFTNormMode::none : FFTNormMode::by_n;
@@ -135,6 +344,7 @@ T compute_factor(int64_t size, FFTNormMode normalization) {
   PADDLE_THROW("Unsupported normalization type");
 }
 
+////////////////// Functors
 template <typename T>
 struct FFTC2CFunctor<platform::CPUDeviceContext, T> {
   void operator()(const platform::CPUDeviceContext& ctx, const Tensor* x,
@@ -167,6 +377,100 @@ struct FFTC2CFunctor<platform::CPUDeviceContext, T> {
   }
 };
 
+template <typename T>
+struct FFTR2CFunctor<platform::CPUDeviceContext, T> {
+  void operator()(const platform::CPUDeviceContext& ctx, const Tensor* x,
+                  Tensor* out, const std::vector<int64_t>& axes,
+                  FFTNormMode normalization, bool forward, bool onesided) {
+    using R = typename T::value_type;
+    using C = std::complex<R>;
+
+    const auto& input_dim = x->dims();
+    const std::vector<size_t> in_sizes =
+        framework::vectorize<size_t>(input_dim);
+    std::vector<int64_t> in_strides =
+        framework::vectorize<int64_t>(framework::stride(input_dim));
+    {
+      const int64_t data_size = sizeof(T);
+      std::transform(in_strides.begin(), in_strides.end(), in_strides.begin(),
+                     [](int64_t s) { return s * data_size; });
+    }
+
+    const auto& output_dim = out->dims();
+    const std::vector<size_t> out_sizes =
+        framework::vectorize<size_t>(output_dim);
+    std::vector<int64_t> out_strides =
+        framework::vectorize<int64_t>(framework::stride(output_dim));
+    {
+      const int64_t data_size = sizeof(C);
+      std::transform(out_strides.begin(), out_strides.end(),
+                     out_strides.begin(),
+                     [](int64_t s) { return s * data_size; });
+    }
+
+    const auto* in_data = x->data<R>();
+    auto* out_data = reinterpret_cast<C*>(out->data<T>());
+    // well, we have to use std::vector<size_t> here
+    std::vector<size_t> axes_(axes.size());
+    std::copy(axes.begin(), axes.end(), axes_.begin());
+    // compuet facet
+    int64_t signal_numel = 1;
+    for (auto i : axes) {
+      signal_numel *= in_sizes[i];
+    }
+    R factor = compute_factor<R>(signal_numel, normalization);
+    pocketfft::r2c(in_sizes, in_strides, out_strides, axes_, forward, in_data,
+                   out_data, factor);
+  }
+};
+
+template <typename T>
+struct FFTC2RFunctor<platform::CPUDeviceContext, T> {
+  void operator()(const platform::CPUDeviceContext& ctx, const Tensor* x,
+                  Tensor* out, const std::vector<int64_t>& axes,
+                  FFTNormMode normalization, bool forward) {
+    using R = typename T::value_type;
+    using C = std::complex<R>;
+
+    const auto& input_dim = x->dims();
+    const std::vector<size_t> in_sizes =
+        framework::vectorize<size_t>(input_dim);
+    std::vector<int64_t> in_strides =
+        framework::vectorize<int64_t>(framework::stride(input_dim));
+    {
+      const int64_t data_size = sizeof(T);
+      std::transform(in_strides.begin(), in_strides.end(), in_strides.begin(),
+                     [](int64_t s) { return s * data_size; });
+    }
+
+    const auto& output_dim = out->dims();
+    const std::vector<size_t> out_sizes =
+        framework::vectorize<size_t>(output_dim);
+    std::vector<int64_t> out_strides =
+        framework::vectorize<int64_t>(framework::stride(output_dim));
+    {
+      const int64_t data_size = sizeof(C);
+      std::transform(out_strides.begin(), out_strides.end(),
+                     out_strides.begin(),
+                     [](int64_t s) { return s * data_size; });
+    }
+
+    const auto* in_data = reinterpret_cast<const C*>(x->data<T>());
+    auto* out_data = out->data<R>();
+    // well, we have to use std::vector<size_t> here
+    std::vector<size_t> axes_(axes.size());
+    std::copy(axes.begin(), axes.end(), axes_.begin());
+    // compuet facet
+    int64_t signal_numel = 1;
+    for (auto i : axes) {
+      signal_numel *= out_sizes[i];
+    }
+    R factor = compute_factor<R>(signal_numel, normalization);
+    pocketfft::c2r(out_sizes, in_strides, out_strides, axes_, forward, in_data,
+                   out_data, factor);
+  }
+};
+
 // mkl fft for all cases
 void exec_fft(const Tensor* x, Tensor* out, const std::vector<int64_t>& out_dim,
               int64_t normalization, bool forward) {
@@ -192,3 +496,29 @@ REGISTER_OP_CPU_KERNEL(
     fft_c2c_grad,
     ops::FFTC2CGradKernel<paddle::platform::CPUDeviceContext, float>,
     ops::FFTC2CGradKernel<paddle::platform::CPUDeviceContext, double>);
+
+REGISTER_OPERATOR(fft_r2c, ops::FFTR2COp, ops::FFTR2COpMaker,
+                  ops::FFTR2CGradOpMaker<paddle::framework::OpDesc>,
+                  ops::FFTR2CGradOpMaker<paddle::imperative::OpBase>);
+REGISTER_OP_CPU_KERNEL(
+    fft_r2c, ops::FFTR2CKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::FFTR2CKernel<paddle::platform::CPUDeviceContext, double>);
+
+REGISTER_OPERATOR(fft_r2c_grad, ops::FFTR2CGradOp);
+REGISTER_OP_CPU_KERNEL(
+    fft_r2c_grad,
+    ops::FFTR2CGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::FFTR2CGradKernel<paddle::platform::CPUDeviceContext, double>);
+
+REGISTER_OPERATOR(fft_c2r, ops::FFTC2ROp, ops::FFTC2ROpMaker,
+                  ops::FFTC2RGradOpMaker<paddle::framework::OpDesc>,
+                  ops::FFTC2RGradOpMaker<paddle::imperative::OpBase>);
+REGISTER_OP_CPU_KERNEL(
+    fft_c2r, ops::FFTC2RKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::FFTC2RKernel<paddle::platform::CPUDeviceContext, double>);
+
+REGISTER_OPERATOR(fft_c2r_grad, ops::FFTC2RGradOp);
+REGISTER_OP_CPU_KERNEL(
+    fft_c2r_grad,
+    ops::FFTC2RGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::FFTC2RGradKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/spectral_op.h
+++ b/paddle/fluid/operators/spectral_op.h
@@ -145,7 +145,7 @@ class FFTC2RKernel : public framework::OpKernel<T> {
     const auto* x = ctx.Input<Tensor>("X");
     auto* y = ctx.Output<Tensor>("Out");
 
-    y->mutable_data<U>(ctx.GetPlace());
+    y->mutable_data<T>(ctx.GetPlace());
     auto normalization = get_norm_from_string(norm_str, forward);
 
     FFTC2RFunctor<DeviceContext, U> fft_c2r_func;

--- a/paddle/fluid/operators/spectral_op.h
+++ b/paddle/fluid/operators/spectral_op.h
@@ -23,26 +23,7 @@ enum class FFTNormMode : int64_t {
   by_n,       // Divide by signal_size
 };
 
-// Convert normalization mode string to enum values
-// NOTE: for different direction, normalization modes have different meanings.
-// eg: "forward" translates to `by_n` for a forward transform and `none` for
-// backward.
-FFTNormMode get_norm_from_string(const std::string& norm, bool forward) {
-  if (norm.empty() || norm == "backward") {
-    return forward ? FFTNormMode::none : FFTNormMode::by_n;
-  }
-
-  if (norm == "forward") {
-    return forward ? FFTNormMode::by_n : FFTNormMode::none;
-  }
-
-  if (norm == "ortho") {
-    return FFTNormMode::by_sqrt_n;
-  }
-
-  PADDLE_THROW(platform::errors::InvalidArgument(
-      "Fft norm string must be forward or backward or ortho"));
-}
+FFTNormMode get_norm_from_string(const std::string& norm, bool forward);
 
 template <typename DeviceContext, typename T>
 struct FFTC2CFunctor {

--- a/paddle/fluid/platform/complex.h
+++ b/paddle/fluid/platform/complex.h
@@ -60,6 +60,8 @@ struct PADDLE_ALIGN(sizeof(T) * 2) complex {
   T real;
   T imag;
 
+  using value_type = T;
+
   complex() = default;
   complex(const complex<T>& o) = default;
   complex& operator=(const complex<T>& o) = default;

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -204,6 +204,8 @@ from .array import array_read  # noqa: F401
 from .array import array_write  # noqa: F401
 from .array import create_array  # noqa: F401
 
+from . import fft
+
 #this list used in math_op_patch.py for _binary_creator_
 tensor_method_func  = [ #noqa
            'matmul',

--- a/python/paddle/tensor/fft.py
+++ b/python/paddle/tensor/fft.py
@@ -231,6 +231,15 @@ def fft_r2c(x, n, axis, norm, forward, onesided):
         outputs = {"Out": [out]}
         helper.append_op(
             type=op_type, inputs=inputs, outputs=outputs, attrs=attrs)
+
+    if not onesided:
+        last_fft_axis = axes[-1]
+        conj_amount = (x.shape[last_fft_axis] - 1) // 2
+        conj_part = paddle.conj(
+            paddle.flip(
+                paddle.slice(out, [last_fft_axis], [1], [1 + conj_amount]),
+                last_fft_axis))
+        out = paddle.concat([out, conj_part], last_fft_axis)
     return out
 
 

--- a/python/paddle/tensor/fft.py
+++ b/python/paddle/tensor/fft.py
@@ -194,11 +194,84 @@ def fft_c2c(x, n, axis, norm, forward):
 
 
 def fft_r2c(x, n, axis, norm, forward, onesided):
-    pass
+    # TODO, move error checking to operators
+    if norm not in ['forward', 'backward', 'ortho']:
+        raise ValueError(
+            "Unexpected norm: {}. Norm should be forward, backward or ortho".
+            form(norm))
+    rank = x.ndim
+    if axis < -rank or axis >= rank:
+        raise ValueError(
+            "Invalid axis. Input's ndim is {}, axis should be [-{}, {})".format(
+                rank, rank, rank))
+    if axis < 0:
+        axis += rank
+    s = [axis]
+    axes = [axis]
+    op_type = 'fft_r2c'
+
+    if in_dygraph_mode():
+        attrs = ('s', s, 'axes', axes, 'normalization', norm, 'forward',
+                 forward, 'onesided', True)
+        out = getattr(_C_ops, op_type)(x, *attrs)
+    else:
+        inputs = {'X': [x], }
+        attrs = {
+            's': s,
+            'axes': axes,
+            'normalization': norm,
+            'forward': forward,
+            'onesided': True,
+        }
+        check_variable_and_dtype(x, 'x', ['float16', 'float32', 'float64'],
+                                 op_type)
+        helper = LayerHelper(op_type, **locals())
+        dtype = helper.input_dtype(input_param_name='x')
+        out = helper.create_variable_for_type_inference(dtype)
+        outputs = {"Out": [out]}
+        helper.append_op(
+            type=op_type, inputs=inputs, outputs=outputs, attrs=attrs)
+    return out
 
 
 def fft_c2r(x, n, axis, norm, forward):
-    pass
+    # TODO, move error checking to operators
+    if norm not in ['forward', 'backward', 'ortho']:
+        raise ValueError(
+            "Unexpected norm: {}. Norm should be forward, backward or ortho".
+            form(norm))
+    rank = x.ndim
+    if axis < -rank or axis >= rank:
+        raise ValueError(
+            "Invalid axis. Input's ndim is {}, axis should be [-{}, {})".format(
+                rank, rank, rank))
+    if axis < 0:
+        axis += rank
+    s = [axis]
+    axes = [axis]
+    op_type = 'fft_c2r'
+
+    if in_dygraph_mode():
+        attrs = ('s', s, 'axes', axes, 'normalization', norm, 'forward',
+                 forward)
+        out = getattr(_C_ops, op_type)(x, *attrs)
+    else:
+        inputs = {'X': [x], }
+        attrs = {
+            's': s,
+            'axes': axes,
+            'normalization': norm,
+            'forward': forward
+        }
+        check_variable_and_dtype(x, 'x', ['float16', 'float32', 'float64'],
+                                 op_type)
+        helper = LayerHelper(op_type, **locals())
+        dtype = helper.input_dtype(input_param_name='x')
+        out = helper.create_variable_for_type_inference(dtype)
+        outputs = {"Out": [out]}
+        helper.append_op(
+            type=op_type, inputs=inputs, outputs=outputs, attrs=attrs)
+    return out
 
 
 def fftn_c2c(x, s, axes, norm, forward):

--- a/python/paddle/tensor/fft.py
+++ b/python/paddle/tensor/fft.py
@@ -14,94 +14,94 @@
 
 import paddle
 from .attribute import is_complex, is_floating_point
-from .framework import in_dygraph_mode
+from ..fluid.framework import in_dygraph_mode
 from .. import _C_ops
 
 
 # public APIs 1d
-def fft(x, n=None, axis=-1, norm=None, name=None):
+def fft(x, n=None, axis=-1, norm="backward", name=None):
     if is_floating_point(x):
         return fft_r2c(x, n, axis, norm, forward=True, onesided=False)
     else:
         return fft_c2c(x, n, axis, norm, forward=True)
 
 
-def ifft(x, n=None, axis=-1, norm=None, name=None):
+def ifft(x, n=None, axis=-1, norm="backward", name=None):
     if is_floating_point(x):
         return fft_r2c(x, n, axis, norm, forward=False, onesided=False)
     else:
         return fft_c2c(x, n, axis, norm, forward=False)
 
 
-def rfft(x, n=None, axis=-1, norm=None, name=None):
+def rfft(x, n=None, axis=-1, norm="backward", name=None):
     return fft_r2c(x, n, axis, norm, forward=True, onesided=True)
 
 
-def irfft(x, n=None, axis=-1, norm=None, name=None):
+def irfft(x, n=None, axis=-1, norm="backward", name=None):
     return fft_c2r(x, n, axis, norm, forward=False)
 
 
-def hfft(x, n=None, axis=-1, norm=None, name=None):
+def hfft(x, n=None, axis=-1, norm="backward", name=None):
     return fft_c2r(x, n, axis, norm, forward=True)
 
 
-def ihfft(x, n=None, axis=-1, norm=None, name=None):
+def ihfft(x, n=None, axis=-1, norm="backward", name=None):
     return fft_r2c(x, n, axis, norm, forward=False, onesided=True)
 
 
 # public APIs nd
-def fftn(x, s=None, axes=None, norm=None, name=None):
+def fftn(x, s=None, axes=None, norm="backward", name=None):
     if is_floating_point(x):
         return fft_r2c(x, s, axes, norm, forward=True, onesided=False)
     else:
         return fft_c2c(x, s, axes, norm, forward=True)
 
 
-def ifftn(x, s=None, axes=None, norm=None, name=None):
+def ifftn(x, s=None, axes=None, norm="backward", name=None):
     if is_floating_point(x):
         return fft_r2c(x, s, axes, norm, forward=False, onesided=False)
     else:
         return fft_c2c(x, s, axes, norm, forward=False)
 
 
-def rfftn(x, s=None, axes=None, norm=None, name=None):
+def rfftn(x, s=None, axes=None, norm="backward", name=None):
     return fft_r2c(x, s, axes, norm, forward=True, onesided=True)
 
 
-def irfftn(x, s=None, axes=None, norm=None, name=None):
+def irfftn(x, s=None, axes=None, norm="backward", name=None):
     return fft_c2r(x, s, axes, norm, forward=False)
 
 
-def hfftn(x, s=None, axes=None, norm=None, name=None):
+def hfftn(x, s=None, axes=None, norm="backward", name=None):
     return fft_c2r(x, s, axes, norm, forward=True)
 
 
-def ihfftn(x, s=None, axes=None, norm=None, name=None):
+def ihfftn(x, s=None, axes=None, norm="backward", name=None):
     return fft_r2c(x, s, axes, norm, forward=False, onesided=True)
 
 
 ## public APIs 2d
-def fft2(x, s=None, axes=(-2, -1), norm=None, name=None):
+def fft2(x, s=None, axes=(-2, -1), norm="backward", name=None):
     return fftn(x, s, axes, norm, name)
 
 
-def ifft2(x, s=None, axes=(-2, -1), norm=None, name=None):
+def ifft2(x, s=None, axes=(-2, -1), norm="backward", name=None):
     return ifftn(x, s, axes, norm, name)
 
 
-def rfft2(x, s=None, axes=(-2, -1), norm=None, name=None):
+def rfft2(x, s=None, axes=(-2, -1), norm="backward", name=None):
     return rfftn(x, s, axes, norm, name)
 
 
-def irfft2(x, s=None, axes=(-2, -1), norm=None, name=None):
+def irfft2(x, s=None, axes=(-2, -1), norm="backward", name=None):
     return irfftn(x, s, axes, norm, name)
 
 
-def hfft2(x, s=None, axes=(-2, -1), norm=None, name=None):
+def hfft2(x, s=None, axes=(-2, -1), norm="backward", name=None):
     return hfftn(x, s, axes, norm, name)
 
 
-def ihfft2(x, s=None, axes=(-2, -1), norm=None, name=None):
+def ihfft2(x, s=None, axes=(-2, -1), norm="backward", name=None):
     return ihfftn(x, s, axes, norm, name)
 
 
@@ -159,7 +159,7 @@ def fft_c2c(x, n, axis, norm, forward):
         raise ValueError(
             "Unexpected norm: {}. Norm should be forward, backward or ortho".
             form(norm))
-    rank = paddle.rank(x)
+    rank = x.ndim
     if axis < -rank or axis >= rank:
         raise ValueError(
             "Invalid axis. Input's ndim is {}, axis should be [-{}, {})".format(
@@ -171,12 +171,17 @@ def fft_c2c(x, n, axis, norm, forward):
     op_type = 'fft_c2c'
 
     if in_dygraph_mode():
-        attrs = ('s', s, 'axes', axes, 'norm', norm, 'forward', forward)
-        out = getattr(_C_ops, "fftc2c")(x, *attrs)
+        attrs = ('s', s, 'axes', axes, 'normalization', norm, 'forward',
+                 forward)
+        out = getattr(_C_ops, op_type)(x, *attrs)
     else:
-        op_type
         inputs = {'X': [x], }
-        attrs = {'s': s, 'axes': axes, 'norm': norm, 'forward': forward}
+        attrs = {
+            's': s,
+            'axes': axes,
+            'normalization': norm,
+            'forward': forward
+        }
         check_variable_and_dtype(x, 'x', ['float16', 'float32', 'float64'],
                                  op_type)
         helper = LayerHelper(op_type, **locals())
@@ -202,7 +207,7 @@ def fftn_c2c(x, s, axes, norm, forward):
         raise ValueError(
             "Unexpected norm: {}. Norm should be forward, backward or ortho".
             form(norm))
-    rank = paddle.rank(x)
+    rank = x.ndim
     if axes is None:
         if s is None:
             axes = list(range(rank))
@@ -229,12 +234,18 @@ def fftn_c2c(x, s, axes, norm, forward):
     op_type = 'fft_c2c'
 
     if in_dygraph_mode():
-        attrs = ('s', s, 'axes', axes, 'norm', norm, 'forward', forward)
+        attrs = ('s', s, 'axes', axes, 'normalization', norm, 'forward',
+                 forward)
         out = getattr(_C_ops, "fftc2c")(x, *attrs)
     else:
         op_type
         inputs = {'X': [x], }
-        attrs = {'s': s, 'axes': axes, 'norm': norm, 'forward': forward}
+        attrs = {
+            's': s,
+            'axes': axes,
+            'normalization': norm,
+            'forward': forward
+        }
         check_variable_and_dtype(x, 'x', ['float16', 'float32', 'float64'],
                                  op_type)
         helper = LayerHelper(op_type, **locals())


### PR DESCRIPTION
1. fix bugs in python interface
2. almost done for pocket fft based fft_c2c.
3. add support for c2r, r2c operators, op makers, kernels and kernel functors.
4. tested for 1D fft, rfft, hfft. rfft. 
5. TODO: R2C with onesided = False is not yet implemented.
6. support onesided=False, flip, conj and concat done in python.
7. add complex<float> and complex<double> support for concat and flip.
8. TODO: add pre-slicing or padding in python.

# fft
<img width="631" alt="图片" src="https://user-images.githubusercontent.com/16222986/129793070-8d85a482-a8a4-4486-9a53-46d2bea4702c.png">

<img width="760" alt="图片" src="https://user-images.githubusercontent.com/16222986/129793025-3f115e86-373b-4f85-af37-7670bb363b23.png">

# rfft
<img width="709" alt="图片" src="https://user-images.githubusercontent.com/16222986/129819929-ce55e6f5-227a-4449-8e70-5f2ac55b4bfe.png">

<img width="791" alt="图片" src="https://user-images.githubusercontent.com/16222986/129819913-2a33d29a-1695-442b-b565-240ca9c2333e.png">


# hfft
<img width="622" alt="图片" src="https://user-images.githubusercontent.com/16222986/129819866-56db11f6-1807-4c47-b76d-aeebb8fe01a0.png">

<img width="766" alt="图片" src="https://user-images.githubusercontent.com/16222986/129819853-b3fe4e34-1214-465d-9f89-8b5ef88f7a19.png">






