### PR TITLE
add mkl-based implementation, change design

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ project(paddle CXX C)
 # enable language CUDA
 # TODO(Shibo Tao): remove find_package(CUDA) completely.
 find_package(CUDA QUIET)
+find_package(MKL QUIET)
+option(WITH_ONEMKL      "Compile PaddlePaddle with oneMKL"              ${MKL_FOUND})
 option(WITH_GPU         "Compile PaddlePaddle with NVIDIA GPU"          ${CUDA_FOUND})
 option(WITH_TENSORRT    "Compile PaddlePaddle with NVIDIA TensorRT"     OFF)
 option(WITH_XPU         "Compile PaddlePaddle with BAIDU KUNLUN XPU"    OFF)
@@ -369,6 +371,10 @@ endif()
 if (WITH_MIPS)
     set(WITH_XBYAK OFF CACHE STRING "Disable XBYAK when compiling WITH_MIPS=ON" FORCE)
     add_definitions(-DPADDLE_WITH_MIPS)
+endif()
+
+if (WITH_ONEMKL)
+    add_definitions(-DPADDLE_WITH_ONEMKL)
 endif()
 
 if (WITH_HETERPS)

--- a/paddle/fluid/operators/CMakeLists.txt
+++ b/paddle/fluid/operators/CMakeLists.txt
@@ -91,21 +91,35 @@ if (WITH_GPU OR WITH_ROCM)
         op_library(warpctc_op DEPS dynload_warpctc sequence_padding sequence_scale SRCS warpctc_op.cc warpctc_op.cu.cc)
     else()
         op_library(warpctc_op DEPS dynload_warpctc sequence_padding sequence_scale)
-        find_library(CUFFT_LIB libcufft.so
-          PATHS
-          ${CUDA_TOOLKIT_ROOT_DIR}/lib64/
-          NO_DEFAULT_PATH
-        )
-        op_library(spectral_op SRCS spectral_op.cc spectral_op.cu DEPS ${OP_HEADER_DEPS})
-        target_link_libraries(spectral_op ${CUFFT_LIB})
     endif()
     op_library(sync_batch_norm_op)
     file(APPEND ${pybind_file} "USE_CUDA_ONLY_OP(sync_batch_norm);\n")
 else()
     op_library(warpctc_op DEPS dynload_warpctc sequence_padding sequence_scale)
-    if(WITH_ONEMKL)
-      target_link_libraries(spectral_op MKL::MKL)
-    endif()
+endif()
+
+op_library(spectral_op SRCS spectral_op.cc spectral_op.cu DEPS ${OP_HEADER_DEPS})
+if (WITH_GPU)
+    find_library(CUFFT_LIB libcufft.so
+        PATHS
+        ${CUDA_TOOLKIT_ROOT_DIR}/lib64/
+        NO_DEFAULT_PATH
+    )
+    target_link_libraries(spectral_op ${CUFFT_LIB})
+endif()
+if(WITH_ONEMKL)
+    find_library(ONEMKL_CORE libmkl_core.so
+        PATHS
+        ${MKL_ROOT}/lib/${MKL_ARCH}
+        NO_DEFAULT_PATH
+    )
+    find_library(ONEMKL_THREAD libmkl_intel_thread.so
+        PATHS
+        ${MKL_ROOT}/lib/${MKL_ARCH}
+        NO_DEFAULT_PATH
+    )
+    target_include_directories(spectral_op PRIVATE ${MKL_INCLUDE})
+    target_link_libraries(spectral_op MKL::mkl_core MKL::mkl_intel_thread)
 endif()
 
 op_library(lstm_op DEPS ${OP_HEADER_DEPS}  lstm_compute)

--- a/paddle/fluid/operators/spectral_op.h
+++ b/paddle/fluid/operators/spectral_op.h
@@ -28,69 +28,6 @@ enum class FFTNormMode : int64_t {
 
 FFTNormMode get_norm_from_string(const std::string& norm, bool forward);
 
-template <typename DeviceContext, typename T>
-struct FFTC2CFunctor {
-  void operator()(const DeviceContext& ctx, const Tensor* X, Tensor* out,
-                  const std::vector<int64_t>& axes, FFTNormMode normalization,
-                  bool forward);
-};
-
-template <typename DeviceContext, typename T>
-struct FFTR2CFunctor {
-  void operator()(const DeviceContext& ctx, const Tensor* X, Tensor* out,
-                  const std::vector<int64_t>& axes, FFTNormMode normalization,
-                  bool forward, bool onesided);
-};
-
-template <typename DeviceContext, typename T>
-struct FFTC2RFunctor {
-  void operator()(const DeviceContext& ctx, const Tensor* X, Tensor* out,
-                  const std::vector<int64_t>& axes, FFTNormMode normalization,
-                  bool forward, bool onesided);
-};
-
-template <typename DeviceContext, typename T>
-class FFTC2CKernel : public framework::OpKernel<T> {
- public:
-  void Compute(const framework::ExecutionContext& ctx) const override {
-    using U = paddle::platform::complex<T>;
-    auto& dev_ctx = ctx.device_context<DeviceContext>();
-
-    auto axes = ctx.Attr<std::vector<int64_t>>("axes");
-    const std::string& norm_str = ctx.Attr<std::string>("normalization");
-    const bool forward = ctx.Attr<bool>("forward");
-    const auto* x = ctx.Input<Tensor>("X");
-    auto* y = ctx.Output<Tensor>("Out");
-
-    y->mutable_data<U>(ctx.GetPlace());
-    auto normalization = get_norm_from_string(norm_str, forward);
-
-    FFTC2CFunctor<DeviceContext, U> fft_c2c_func;
-    fft_c2c_func(dev_ctx, x, y, axes, normalization, forward);
-  }
-};
-
-template <typename DeviceContext, typename T>
-class FFTC2CGradKernel : public framework::OpKernel<T> {
- public:
-  void Compute(const framework::ExecutionContext& ctx) const override {
-    using U = paddle::platform::complex<T>;
-    auto& dev_ctx = ctx.device_context<DeviceContext>();
-
-    auto axes = ctx.Attr<std::vector<int64_t>>("axes");
-    const std::string& norm_str = ctx.Attr<std::string>("normalization");
-    const bool forward = ctx.Attr<bool>("forward");
-    const auto* dy = ctx.Input<Tensor>(framework::GradVarName("Out"));
-    auto* dx = ctx.Output<Tensor>(framework::GradVarName("X"));
-
-    dx->mutable_data<U>(ctx.GetPlace());
-    auto normalization = get_norm_from_string(norm_str, forward);
-
-    FFTC2CFunctor<DeviceContext, U> fft_c2c_func;
-    fft_c2c_func(dev_ctx, dy, dx, axes, normalization, forward);
-  }
-};
-
 // Enum representing the FFT type
 enum class FFTTransformType : int8_t {
   C2C,  // Complex-to-complex
@@ -142,11 +79,74 @@ inline bool has_complex_output(FFTTransformType type) {
   PADDLE_THROW(platform::errors::InvalidArgument("Unknown FFTTransformType"));
 }
 
+template <typename DeviceContext, typename Ti, typename To>
+struct FFTC2CFunctor {
+  void operator()(const DeviceContext& ctx, const Tensor* X, Tensor* out,
+                  const std::vector<int64_t>& axes, FFTNormMode normalization,
+                  bool forward);
+};
+
+template <typename DeviceContext, typename Ti, typename To>
+struct FFTR2CFunctor {
+  void operator()(const DeviceContext& ctx, const Tensor* X, Tensor* out,
+                  const std::vector<int64_t>& axes, FFTNormMode normalization,
+                  bool forward, bool onesided);
+};
+
+template <typename DeviceContext, typename Ti, typename To>
+struct FFTC2RFunctor {
+  void operator()(const DeviceContext& ctx, const Tensor* X, Tensor* out,
+                  const std::vector<int64_t>& axes, FFTNormMode normalization,
+                  bool forward, bool onesided);
+};
+
+template <typename DeviceContext, typename T>
+class FFTC2CKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    using C = paddle::platform::complex<T>;
+    auto& dev_ctx = ctx.device_context<DeviceContext>();
+
+    auto axes = ctx.Attr<std::vector<int64_t>>("axes");
+    const std::string& norm_str = ctx.Attr<std::string>("normalization");
+    const bool forward = ctx.Attr<bool>("forward");
+    const auto* x = ctx.Input<Tensor>("X");
+    auto* y = ctx.Output<Tensor>("Out");
+
+    y->mutable_data<C>(ctx.GetPlace());
+    auto normalization = get_norm_from_string(norm_str, forward);
+
+    FFTC2CFunctor<DeviceContext, C, C> fft_c2c_func;
+    fft_c2c_func(dev_ctx, x, y, axes, normalization, forward);
+  }
+};
+
+template <typename DeviceContext, typename T>
+class FFTC2CGradKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    using C = paddle::platform::complex<T>;
+    auto& dev_ctx = ctx.device_context<DeviceContext>();
+
+    auto axes = ctx.Attr<std::vector<int64_t>>("axes");
+    const std::string& norm_str = ctx.Attr<std::string>("normalization");
+    const bool forward = ctx.Attr<bool>("forward");
+    const auto* dy = ctx.Input<Tensor>(framework::GradVarName("Out"));
+    auto* dx = ctx.Output<Tensor>(framework::GradVarName("X"));
+
+    dx->mutable_data<C>(ctx.GetPlace());
+    auto normalization = get_norm_from_string(norm_str, forward);
+
+    FFTC2CFunctor<DeviceContext, C, C> fft_c2c_func;
+    fft_c2c_func(dev_ctx, dy, dx, axes, normalization, forward);
+  }
+};
+
 template <typename DeviceContext, typename T>
 class FFTR2CKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
-    using U = paddle::platform::complex<T>;
+    using C = paddle::platform::complex<T>;
     auto& dev_ctx = ctx.device_context<DeviceContext>();
 
     auto axes = ctx.Attr<std::vector<int64_t>>("axes");
@@ -156,10 +156,10 @@ class FFTR2CKernel : public framework::OpKernel<T> {
     const auto* x = ctx.Input<Tensor>("X");
     auto* y = ctx.Output<Tensor>("Out");
 
-    y->mutable_data<U>(ctx.GetPlace());
+    y->mutable_data<C>(ctx.GetPlace());
     auto normalization = get_norm_from_string(norm_str, forward);
 
-    FFTR2CFunctor<DeviceContext, U> fft_r2c_func;
+    FFTR2CFunctor<DeviceContext, T, C> fft_r2c_func;
     fft_r2c_func(dev_ctx, x, y, axes, normalization, forward, onesided);
   }
 };
@@ -168,7 +168,7 @@ template <typename DeviceContext, typename T>
 class FFTR2CGradKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
-    using U = paddle::platform::complex<T>;
+    using C = paddle::platform::complex<T>;
     auto& dev_ctx = ctx.device_context<DeviceContext>();
 
     auto axes = ctx.Attr<std::vector<int64_t>>("axes");
@@ -178,10 +178,10 @@ class FFTR2CGradKernel : public framework::OpKernel<T> {
     const auto* dy = ctx.Input<Tensor>(framework::GradVarName("Out"));
     auto* dx = ctx.Output<Tensor>(framework::GradVarName("X"));
 
-    dx->mutable_data<U>(ctx.GetPlace());
+    dx->mutable_data<C>(ctx.GetPlace());
     auto normalization = get_norm_from_string(norm_str, forward);
 
-    FFTC2RFunctor<DeviceContext, U> fft_c2r_func;
+    FFTC2RFunctor<DeviceContext, C, T> fft_c2r_func;
     fft_c2r_func(dev_ctx, dy, dx, axes, normalization, forward);
   }
 };
@@ -190,7 +190,7 @@ template <typename DeviceContext, typename T>
 class FFTC2RKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
-    using U = paddle::platform::complex<T>;
+    using C = paddle::platform::complex<T>;
     auto& dev_ctx = ctx.device_context<DeviceContext>();
 
     auto axes = ctx.Attr<std::vector<int64_t>>("axes");
@@ -202,7 +202,7 @@ class FFTC2RKernel : public framework::OpKernel<T> {
     y->mutable_data<T>(ctx.GetPlace());
     auto normalization = get_norm_from_string(norm_str, forward);
 
-    FFTC2RFunctor<DeviceContext, U> fft_c2r_func;
+    FFTC2RFunctor<DeviceContext, C, T> fft_c2r_func;
     fft_c2r_func(dev_ctx, x, y, axes, normalization, forward);
   }
 };
@@ -211,7 +211,7 @@ template <typename DeviceContext, typename T>
 class FFTC2RGradKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
-    using U = paddle::platform::complex<T>;
+    using C = paddle::platform::complex<T>;
     auto& dev_ctx = ctx.device_context<DeviceContext>();
 
     auto axes = ctx.Attr<std::vector<int64_t>>("axes");
@@ -221,10 +221,10 @@ class FFTC2RGradKernel : public framework::OpKernel<T> {
     const auto* dy = ctx.Input<Tensor>(framework::GradVarName("Out"));
     auto* dx = ctx.Output<Tensor>(framework::GradVarName("X"));
 
-    dx->mutable_data<U>(ctx.GetPlace());
+    dx->mutable_data<C>(ctx.GetPlace());
     auto normalization = get_norm_from_string(norm_str, forward);
 
-    FFTR2CFunctor<DeviceContext, U> fft_r2c_func;
+    FFTR2CFunctor<DeviceContext, T, C> fft_r2c_func;
     fft_r2c_func(dev_ctx, dy, dx, axes, normalization, forward, onesided);
   }
 };


### PR DESCRIPTION
1. implement mkl-based fft, FFTC2CFunctor and common function exec_fft;
2. change the design, add input and output typename as template parameter for all FFTFunctors, update pocketfft-based implementation.