### PR TITLE
complete fft c2c on gpu in ND

### DIFF
--- a/paddle/fluid/operators/eigen/scale.cc
+++ b/paddle/fluid/operators/eigen/scale.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 #include "paddle/fluid/operators/eigen/eigen_function.h"
 #include "paddle/fluid/platform/bfloat16.h"
+#include "paddle/fluid/platform/complex.h"
 
 namespace paddle {
 namespace operators {
@@ -42,6 +43,8 @@ template struct EigenScale<Eigen::DefaultDevice, int8_t>;
 template struct EigenScale<Eigen::DefaultDevice, int16_t>;
 template struct EigenScale<Eigen::DefaultDevice, int>;
 template struct EigenScale<Eigen::DefaultDevice, int64_t>;
+template struct EigenScale<Eigen::DefaultDevice, platform::complex<float>>;
+template struct EigenScale<Eigen::DefaultDevice, platform::complex<double>>;
 
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/operators/eigen/scale.cu
+++ b/paddle/fluid/operators/eigen/scale.cu
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 #include "paddle/fluid/operators/eigen/eigen_function.h"
+#include "paddle/fluid/platform/complex.h"
 #include "paddle/fluid/platform/float16.h"
 
 namespace paddle {
@@ -41,6 +42,8 @@ template struct EigenScale<Eigen::GpuDevice, int16_t>;
 template struct EigenScale<Eigen::GpuDevice, int>;
 template struct EigenScale<Eigen::GpuDevice, int64_t>;
 template struct EigenScale<Eigen::GpuDevice, platform::float16>;
+template struct EigenScale<Eigen::GpuDevice, platform::complex<float>>;
+template struct EigenScale<Eigen::GpuDevice, platform::complex<double>>;
 
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/operators/spectral_op.h
+++ b/paddle/fluid/operators/spectral_op.h
@@ -11,8 +11,10 @@
 
 #pragma once
 #include "paddle/fluid/framework/data_type.h"
+#include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/tensor.h"
+#include "paddle/fluid/operators/eigen/eigen_function.h"
 #include "paddle/fluid/platform/complex.h"
 
 namespace paddle {

--- a/python/paddle/tensor/fft.py
+++ b/python/paddle/tensor/fft.py
@@ -298,15 +298,15 @@ def fftn_c2c(x, s, axes, norm, forward):
             fft_ndims = len(s)
             axes = list(range(rank - fft_ndims, rank))
     else:
-        axes_ = axes.copy()
-        for i in len(axes_):
-            if axes_[i] < -rank or axes_[i] >= rank:
+        axes = list(axes)
+        for i in range(len(axes)):
+            if axes[i] < -rank or axes[i] >= rank:
                 raise ValueError(
                     "Invalid axis. Input's ndim is {}, axis should be [-{}, {})".
                     format(rank, rank, rank))
-            if axes_[i] < 0:
-                axes_[i] += rank
-        axes = axes_
+            if axes[i] < 0:
+                axes[i] += rank
+        axes = axes
         axes.sort()
         if s is None:
             shape = paddle.shape(x)


### PR DESCRIPTION
PR types
New features

PR changes
OPs

Describe
1. complete fft c2c on gpu in ND
2. complete normalization function

paddle.set_printoptions(precision=8, threshold=10000)
torch.set_printoptions(precision=8, threshold=10000)
np.set_printoptions(precision=8, threshold=10000)
np.random.seed(42)
x = (np.random.randn(4, 2, 2, 2, 2, 2) + 1j * np.random.randn(4, 2, 2, 2, 2, 2)).astype(np.complex64)
print(x)
print("numpy========================")
fft_x = np.fft.fftn(x)
print(fft_x)
print("pytorch======================")
xt = torch.tensor(x, device=torch.device('cuda:0'))
fft_xt = torch.fft.fftn(xt).cpu().numpy()
print(fft_xt)
print("paddle=======================")
xp = paddle.to_tensor(x)
fft_xp = paddle.tensor.fft.fftn(xp).numpy()
print(fft_xp)
print("allclose of paddle and pytorch is: %s" % np.allclose(fft_xt, fft_xp, rtol=1e-6, atol=0))
print("allclose of paddle and numpy is: %s" % np.allclose(fft_x, fft_xp, rtol=1e-6, atol=0))