### PR TITLE
fix MKL based FFT implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ project(paddle CXX C)
 # enable language CUDA
 # TODO(Shibo Tao): remove find_package(CUDA) completely.
 find_package(CUDA QUIET)
-find_package(MKL QUIET)
+find_package(MKL CONFIG QUIET)
 option(WITH_ONEMKL      "Compile PaddlePaddle with oneMKL"              ${MKL_FOUND})
 option(WITH_GPU         "Compile PaddlePaddle with NVIDIA GPU"          ${CUDA_FOUND})
 option(WITH_TENSORRT    "Compile PaddlePaddle with NVIDIA TensorRT"     OFF)

--- a/paddle/fluid/operators/spectral_op.h
+++ b/paddle/fluid/operators/spectral_op.h
@@ -140,7 +140,7 @@ class FFTC2CGradKernel : public framework::OpKernel<T> {
     auto normalization = get_norm_from_string(norm_str, forward);
 
     FFTC2CFunctor<DeviceContext, C, C> fft_c2c_func;
-    fft_c2c_func(dev_ctx, dy, dx, axes, normalization, forward);
+    fft_c2c_func(dev_ctx, dy, dx, axes, normalization, !forward);
   }
 };
 

--- a/python/paddle/tensor/fft.py
+++ b/python/paddle/tensor/fft.py
@@ -293,7 +293,7 @@ def fftn_c2c(x, s, axes, norm, forward):
     if axes is None:
         if s is None:
             axes = list(range(rank))
-            s = paddle.shape(x)
+            s = x.shape
         else:
             fft_ndims = len(s)
             axes = list(range(rank - fft_ndims, rank))
@@ -309,7 +309,7 @@ def fftn_c2c(x, s, axes, norm, forward):
         axes = axes
         axes.sort()
         if s is None:
-            shape = paddle.shape(x)
+            shape = x.shape
             s = [shape[axis] for axis in axes]
         else:
             assert len(axes) == len(s)


### PR DESCRIPTION
1. fix MKL-based FFT implementation. (C2C functions[1d, nd, forward, backward] have been tested)
2. simplify spectral_op target when compiling with MKL.