### PR TITLE
fix C2R and R2C for cufft

### DIFF
--- a/python/paddle/tensor/fft.py
+++ b/python/paddle/tensor/fft.py
@@ -409,7 +409,7 @@ def fftn_c2r(x, s, axes, norm, forward):
         raise ValueError(
             "Unexpected norm: {}. Norm should be forward, backward or ortho".
             form(norm))
-    s = list(s)
+    s = list(s) if s is not None else s
     rank = x.ndim
     if axes is None:
         if s is None:


### PR DESCRIPTION
Since cufft's C2R and R2C is implicitly inverse and forward, respectively. In these cases, direction is not an option.

Executing C2R in forward would cause a CUFFT_INVALID_VALUE.