### PR TITLE
add fft r2c op and kernel function with cpu pocketfft, cpu mkl, and Cuda

### DIFF
--- a/paddle/fluid/framework/data_type.h
+++ b/paddle/fluid/framework/data_type.h
@@ -15,6 +15,7 @@ limitations under the License. */
 #pragma once
 #include <string>
 #include <typeindex>
+#include <iostream>
 
 #include "paddle/fluid/framework/framework.pb.h"
 #include "paddle/fluid/platform/bfloat16.h"
@@ -171,6 +172,7 @@ extern inline proto::VarType::Type ToComplexType(proto::VarType::Type t) {
 }
 
 extern inline proto::VarType::Type ToRealType(proto::VarType::Type t) {
+  std::cout<<t<<std::endl;
   switch (t) {
     case proto::VarType::COMPLEX64:
       return proto::VarType::FP32;

--- a/paddle/fluid/operators/spectral_op.cc
+++ b/paddle/fluid/operators/spectral_op.cc
@@ -184,6 +184,7 @@ class FFTR2CGradOpMaker : public framework::SingleGradOpMaker<T> {
  protected:
   void Apply(GradOpPtr<T> grad_op) const override {
     grad_op->SetType("fft_r2c_grad");
+    grad_op->SetInput("X", this->Input("X"));
     grad_op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
     grad_op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
     grad_op->SetAttrMap(this->Attrs());
@@ -204,19 +205,7 @@ class FFTR2CGradOp : public framework::OperatorWithKernel {
         platform::errors::InvalidArgument(
             "Output(%s) of FFTR2CGradOp should not be null.", "DX"));
     auto x_grad_name = framework::GradVarName("X");
-    auto out_grad_name = framework::GradVarName("Out");
-    const bool onesided = ctx->Attrs().Get<bool>("onesided");
-    const auto axes = ctx->Attrs().Get<std::vector<int64_t>>("axes");
-    if (!onesided) {
-      ctx->ShareDim(out_grad_name, /*->*/ x_grad_name);  //
-    } else {
-      const auto out_grad_dim = ctx->GetInputDim(out_grad_name);
-      framework::DDim x_grad_dim(out_grad_dim);
-      const int64_t last_fft_axis = axes.back();
-      const int64_t last_fft_dim_size = x_grad_dim.at(last_fft_axis);
-      x_grad_dim.at(last_fft_axis) = (last_fft_dim_size - 1) * 2;
-      ctx->SetOutputDim(x_grad_name, x_grad_dim);
-    }
+    ctx->ShareDim("X", /*->*/ x_grad_name);  //
   }
 
  protected:
@@ -370,6 +359,9 @@ T compute_factor(int64_t size, FFTNormMode normalization) {
   PADDLE_THROW("Unsupported normalization type");
 }
 
+void fill_with_conjugate_symetry_cpu(const Tensor& input, const std::vector<int64_t>& axes) {
+
+}
 ////////////////// Functors
 #if defined(PADDLE_WITH_ONEMKL)
 
@@ -848,7 +840,14 @@ template <typename Ti, typename To>
 struct FFTR2CFunctor<platform::CPUDeviceContext, Ti, To> {
   void operator()(const platform::CPUDeviceContext& ctx, const Tensor* x,
                   Tensor* out, const std::vector<int64_t>& axes,
-                  FFTNormMode normalization, bool forward, bool onesided) {}
+                  FFTNormMode normalization, bool forward, bool onesided) {
+    VLOG(5) << "[FFT][R2C][CPU][MKL]:" << "Exec FFTR2CFunctor(onsided=" << onesided << ", forward=" << forward <<")";
+    exec_fft<platform::CPUDeviceContext, Ti, To>(ctx, x, out, axes,
+                                                 normalization, forward);
+    if (!onesided) {
+      fill_with_conjugate_symetry_cpu(*out, axes);
+    }
+  }
 };
 
 template <typename Ti, typename To>

--- a/paddle/fluid/operators/spectral_op.cu
+++ b/paddle/fluid/operators/spectral_op.cu
@@ -630,7 +630,7 @@ void exec_fft(const DeviceContext& ctx, Tensor* out, const Tensor* X,
   output.mutable_data<To>(tensor_place);
 
   // Create the transform plan (either from cache or locally)
-  const auto value_type = framework::ToRealType(input.type());
+  const auto value_type = framework::IsComplexType(input.type())?framework::ToRealType(input.type()):input.type();
   auto fft_type = GetFFTTransformType(input.type(), output.type());
   PlanKey Key(framework::vectorize(input.dims()),
               framework::vectorize(output.dims()), signal_size, fft_type,
@@ -747,6 +747,11 @@ void exec_normalization(const DeviceContext& ctx, const Tensor* in, Tensor* out,
   }
 }
 
+// TODO: fill other half tensor with conjugate symmetry
+template <typename DeviceContext, typename T>
+void fill_with_conj_symmetry(Tensor* in, const std::vector<int64_t> axes) {
+}
+
 }  // anonymous namespace
 
 // Use the optimized path to perform single R2C or C2R if transformation dim is
@@ -839,12 +844,36 @@ struct FFTC2RFunctor<platform::CUDADeviceContext, Ti, To> {
   }
 };
 
+// n dimension real to complex FFT use cufft lib
 template <typename Ti, typename To>
 struct FFTR2CFunctor<platform::CUDADeviceContext, Ti, To> {
   void operator()(const platform::CUDADeviceContext& ctx, const Tensor* X,
                   Tensor* out, const std::vector<int64_t>& axes,
-                  FFTNormMode normalization, bool forward, bool onesided) {}
+                  FFTNormMode normalization, bool forward, bool onesided) {
+    // Step1: R2C transform on the last dimension
+    framework::Tensor* r2c_out = out; 
+    const std::vector<int64_t> last_dim{axes.back()};
+    std::vector<int64_t> out_dims = framework::vectorize(out->dims());
+    exec_fft<platform::CUDADeviceContext, Ti, To>(ctx, r2c_out, X, out_dims, last_dim, forward);
+
+    // Step2: C2C transform on the remaining dimension
+    framework::Tensor c2c_out;
+    if (axes.size() > 1) {
+      c2c_out.mutable_data<To>(out->dims(), ctx.GetPlace());
+      std::vector<int64_t>  remain_dim(axes.begin(), axes.end()-1);
+      FFTC2CFunctor<platform::CUDADeviceContext, To, To> fft_c2c_func;
+      fft_c2c_func(ctx, &c2c_out, r2c_out, remain_dim, FFTNormMode::none, forward);
+    }
+
+ 
+    const auto in_sizes = framework::vectorize(X->dims());
+    framework::Tensor* norm_tensor = axes.size()>1 ? &c2c_out : r2c_out;
+    exec_normalization<platform::CUDADeviceContext, To>(
+        ctx, norm_tensor, out, normalization, in_sizes, axes);
+  }
 };
+
+>>>>>>> add fft r2c onesided with cpu(pocketfft/mkl) and gpu
 
 }  // namespace operators
 }  // namespace paddle
@@ -860,6 +889,7 @@ REGISTER_OP_CUDA_KERNEL(
     ops::FFTC2CGradKernel<paddle::platform::CUDADeviceContext, double>);
 
 REGISTER_OP_CUDA_KERNEL(
+<<<<<<< 9f16534355db9c798119d872d041014bb7deeca8
     fft_c2r, ops::FFTC2RKernel<paddle::platform::CUDADeviceContext, float>,
     ops::FFTC2RKernel<paddle::platform::CUDADeviceContext, double>);
 
@@ -876,3 +906,12 @@ REGISTER_OP_CUDA_KERNEL(
     fft_r2c_grad,
     ops::FFTR2CGradKernel<paddle::platform::CUDADeviceContext, float>,
     ops::FFTR2CGradKernel<paddle::platform::CUDADeviceContext, double>);
+=======
+  fft_r2c, ops::FFTR2CKernel<paddle::platform::CUDADeviceContext, float>,
+  ops::FFTR2CKernel<paddle::platform::CUDADeviceContext, double>);
+  
+REGISTER_OP_CUDA_KERNEL(
+    fft_r2c_grad,
+    ops::FFTR2CGradKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::FFTR2CGradKernel<paddle::platform::CUDADeviceContext, double>);
+>>>>>>> add fft r2c onesided with cpu(pocketfft/mkl) and gpu

--- a/python/paddle/fluid/tests/unittests/test_spectral_op.py
+++ b/python/paddle/fluid/tests/unittests/test_spectral_op.py
@@ -1,0 +1,9 @@
+import numpy as numpy
+import paddle
+import torch
+
+
+from op_test import OpTest
+
+
+def 


### PR DESCRIPTION
complete  fft r2c with oneside=True, and compare output and grad number with pytorch.   include:
1. cpu pocketfft 
2. cpu mkl  
3. gpu cufft
4. grad kernel

test scripts:

```python
import paddle
import torch
import numpy as np

np.set_printoptions(2)

paddle.set_device('cpu')
device = torch.device('cpu')

x = np.random.randn(8)
dy = np.random.randn(5) + 1j*np.random.randn(5)

# print('paddle----------')
px = paddle.to_tensor(x, stop_gradient=False)
pdy = paddle.to_tensor(dy)
py = paddle.tensor.fft.rfft(px)
py.backward(pdy)


# print('torch----------')
tx = torch.tensor(x, requires_grad=True)
tx.to(device)
tdy = torch.tensor(dy)
tdy.to(device)
ty = torch.fft.rfft(tx)
ty.backward(tdy)

print('-------------------1-dim allclose: ', np.allclose(py.numpy(), ty.detach().numpy(), rtol=1e-6, atol=0))
print('-------------------1-dim grad close: ', np.allclose(px.grad.numpy(), tx.grad.detach().numpy(), rtol=1e-6, atol=0))




x = np.random.randn(840).reshape(4,5,6,7)
dy = np.random.randn(480).reshape(4,5,6,4) + 1j*np.random.randn(480).reshape(4,5,6,4)

# print('paddle----------')
px = paddle.to_tensor(x, stop_gradient=False)
pdy = paddle.to_tensor(dy)
py = paddle.tensor.fft.rfftn(px)
py.backward(pdy)


# print('torch----------')
tx = torch.tensor(x, requires_grad=True)
tx.to(device)
tdy = torch.tensor(dy)
tdy.to(device)
ty = torch.fft.rfftn(tx)
ty.backward(tdy)


print('------------------n-dim allclose: ', np.allclose(py.numpy(), ty.detach().numpy(), rtol=1e-6, atol=0))
print('------------------n-dim grad close: ', np.allclose(px.grad.numpy(), tx.grad.detach().numpy(), rtol=1e-6, atol=0))


x = np.random.randn(840).reshape(4,5,6,7).astype('float64')
dy = np.random.randn(480).reshape(4,5,6,4).astype('float64') + 1j*np.random.randn(480).reshape(4,5,6,4).astype('float64')

# print('paddle----------')
px = paddle.to_tensor(x, stop_gradient=False)
pdy = paddle.to_tensor(dy)
py = paddle.tensor.fft.rfftn(px)
py.backward(pdy)


# print('torch----------')
tx = torch.tensor(x, requires_grad=True)
tx.to(device)
tdy = torch.tensor(dy)
tdy.to(device)
ty = torch.fft.rfftn(tx)
ty.backward(tdy)  

print('--------------------------n-dim float64 allclose: ', np.allclose(py.numpy(), ty.detach().numpy(), rtol=1e-6, atol=0))
print('--------------------------n-dim grad float64 close: ', np.allclose(px.grad.numpy(), tx.grad.detach().numpy(), rtol=1e-6, atol=0))




# x = np.random.randn(840).reshape(4,5,6,7).astype('float64')
# px = paddle.to_tensor(x)
# py = paddle.tensor.fft.rfftn(px)
# paddle.tensor.fft.ihfftn(px)
# print('n-dim forward=false allclose:', np.allclose(x, new_x, rtol=1e-6, atol=0))
```
